### PR TITLE
Hold start to show notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ Golden Sun practice tool: BizHawk Lua script that reads a notes CSV file and dis
 
 ## Usage
 
-Load `gs-encounter-notes-overlay.lua` from BizHawk 2.8's Lua Console while playing Golden Sun.
+Load `gs-encounter-notes-overlay.lua` from BizHawk's Lua Console while playing Golden Sun.
 
-The `gs-encounter-notes.csv` file in the same folder, will drive the information displayed on-screen.
+The `gs-encounter-notes.csv` file in the same folder will drive the information displayed on-screen.
+
+**Hold start** to show notes for the encounter.
+Each target will be numbered and if an encounter set has notes, actions for each character will be displayed along with any extra notes.
+
+This has been tested successfully with BizHawk 2.8, 2.9, and 2.9.1.
+
 If the file does not exist, one will be downloaded automatically.
-
-This has not been tested with any other emulator version.
 
 This has not been tested with Golden Sun: The Lost Age, but support will come.
 

--- a/src/Controller.lua
+++ b/src/Controller.lua
@@ -2,6 +2,7 @@ local NotesFile = require 'NotesFile'
 local GameData = require 'GameData'
 local Overlay = require 'Overlay'
 local Downloader = require 'Downloader'
+local bhJoypad = joypad
 
 local allNotes = {}
 local currentEncounter = nil
@@ -11,6 +12,9 @@ local reversePolarity = false
 local lastQueuedCommandCount = nil
 local setPositionsWait = -1
 local newBattle = false
+
+local drawNotes = false
+local drawNumbers = false
 
 local Controller = {}
 
@@ -72,6 +76,8 @@ function Controller.frame()
         currentNotes = nil
         lastQueuedCommandCount = nil
         Overlay.clear()
+        drawNotes = false
+        drawNumbers = false
 
     elseif currentEnemyCount > 0 then
         if currentEncounter == nil then --Encounter begins
@@ -130,10 +136,10 @@ function Controller.frame()
                 if queuedCommandCount ~= lastQueuedCommandCount then
                     --drawing anything on a frame resets previous drawings
                     if queuedCommandCount == 0 or newBattle then
-                        Overlay.drawNumbers(currentEnemyCount)
-                        Overlay.drawNotes(currentNotes)
+                        drawNumbers = true
+                        drawNotes = true
                     elseif queuedCommandCount == currentBattleSize then
-                        Overlay.drawNotes(currentNotes)
+                        drawNotes = true
                     end
                 end
             end
@@ -141,6 +147,18 @@ function Controller.frame()
             lastQueuedCommandCount = queuedCommandCount
             newBattle = false
         end
+    end
+
+    local input = bhJoypad.get()
+    if input['Start'] then
+        if drawNotes then
+            Overlay.drawNotes(currentNotes)
+        end
+        if drawNumbers then
+            Overlay.drawNumbers(currentEnemyCount)
+        end
+    else
+        Overlay.clear()
     end
 end
 

--- a/src/Controller.lua
+++ b/src/Controller.lua
@@ -3,7 +3,7 @@ local GameData = require 'GameData'
 local Overlay = require 'Overlay'
 local Downloader = require 'Downloader'
 
-local allNotes = nil
+local allNotes = {}
 local currentEncounter = nil
 local currentBattleSize = 0
 local currentNotes = nil
@@ -32,19 +32,26 @@ end
 
 function Controller.init(notesFile, downloadUrl)
     local test = io.open(notesFile, 'r')
+    local doLoad = false
     if test == nil then
         if downloadUrl == nil then
-            error("Cannot proceed, " .. notesFile .. " does not exist")
-        end
-
-        print(notesFile .. " not found, downloading from " .. downloadUrl)
-        if Downloader.get(downloadUrl, notesFile) == false then
-            error("Download failed, please place a " .. notesFile .. " in the same folder as gs-encounter-notes-overlay.lua")
+            print("No notes loaded, " .. notesFile .. " does not exist")
+        else
+            print(notesFile .. " not found, downloading from " .. downloadUrl)
+            doLoad = Downloader.get(downloadUrl, notesFile)
+            if not doLoad then
+                print("WARNING: Download failed, please place a " .. notesFile .. " in the same folder as gs-encounter-notes-overlay.lua")
+            end
         end
     else
         io.close(test)
+        doLoad = true
     end
-    allNotes = NotesFile.load(notesFile)
+
+    if doLoad then
+        allNotes = NotesFile.load(notesFile)
+    end
+
     Overlay.clear()
     print("")
     print("Golden Sun Encounter Notes script prepped and ready")

--- a/src/Controller.lua
+++ b/src/Controller.lua
@@ -123,8 +123,6 @@ function Controller.frame()
                 if queuedCommandCount ~= lastQueuedCommandCount then
                     --drawing anything on a frame resets previous drawings
                     if queuedCommandCount == 0 or newBattle then
-                        --enemy sprites start after party sprites, which start at index 1
-                        local enemyPositions = GameData.spriteData:positionsArray(GameData.partyFlags:partySize() + 1, currentEnemyCount)
                         Overlay.drawNumbers(currentEnemyCount)
                         Overlay.drawNotes(currentNotes)
                     elseif queuedCommandCount == currentBattleSize then

--- a/src/GameData.lua
+++ b/src/GameData.lua
@@ -71,14 +71,7 @@ function GameData.enemyNames:asArray(encounterSize)
 
     local names = {}
     for i = 0,encounterSize-1 do
-        local data = self:read(i)
-        local str = {}
-        for _, v in ipairs(data) do
-            if v > 0 then
-                table.insert(str, string.char(v))
-            end
-        end
-        table.insert(names, table.concat(str))
+        table.insert(names, self:readString(i))
     end
 
     return names

--- a/src/MemoryStructure.lua
+++ b/src/MemoryStructure.lua
@@ -8,11 +8,23 @@ local MemoryStructure = class(function (o, offset, iterator, size, reader)
 end)
 
 function MemoryStructure:read(index, skip)
+    index = index or 0
     skip = skip or 0
     if self.size then
         return self.reader(self.offset + skip + index*self.iterator, self.size)
     end
     return self.reader(self.offset + skip + index*self.iterator)
+end
+
+function MemoryStructure:readString(index)
+    local data = self:read(index)
+    local str = {}
+    for _, v in ipairs(data) do
+        if v > 0 then
+            table.insert(str, string.char(v))
+        end
+    end
+    return table.concat(str)
 end
 
 return MemoryStructure

--- a/src/NotesFile.lua
+++ b/src/NotesFile.lua
@@ -37,8 +37,10 @@ end
 
 function wordSplit(str)
     local result = {}
-    for chunk in str:gmatch('%S+') do 
-        table.insert(result, chunk) 
+    if str then
+        for chunk in str:gmatch('%S+') do
+            table.insert(result, chunk)
+        end
     end
     return result
 end

--- a/src/NotesFile.lua
+++ b/src/NotesFile.lua
@@ -35,7 +35,7 @@ function decodeNote(fields)
     return row
 end
 
-function wordSplit(str, char)
+function wordSplit(str)
     local result = {}
     for chunk in str:gmatch('%S+') do 
         table.insert(result, chunk) 


### PR DESCRIPTION
- Only show notes when Start button is held to allow player to use the tool to reveal information more as a check rather than as an immediate crutch.
- Incorporates other cleanup from TLA WIP branch